### PR TITLE
feat: Add Context Menu Search (#19)

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,5 +1,21 @@
+import { generateSearchUrl } from '../utils/search'
+
 console.info('Discogs Enhancer: Background script loaded')
 
 chrome.runtime.onInstalled.addListener(() => {
     console.info('Discogs Enhancer: Extension installed')
+
+    // Create context menu for selected text
+    chrome.contextMenus.create({
+        id: 'search-on-discogs',
+        title: 'Search "%s" on Discogs',
+        contexts: ['selection'],
+    })
+})
+
+chrome.contextMenus.onClicked.addListener((info) => {
+    if (info.menuItemId === 'search-on-discogs' && info.selectionText) {
+        const url = generateSearchUrl(info.selectionText)
+        chrome.tabs.create({ url })
+    }
 })

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -42,7 +42,8 @@ const manifest = defineManifest(async () => ({
     permissions: [
         'storage',
         'activeTab',
-        'scripting'
+        'scripting',
+        'contextMenus'
     ],
     web_accessible_resources: [
         {

--- a/src/utils/search.test.ts
+++ b/src/utils/search.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { generateSearchUrl } from './search'
+
+describe('Search Utils', () => {
+    it('should generate a valid Discogs search URL', () => {
+        expect(generateSearchUrl('Beatles')).toBe('https://www.discogs.com/search/?q=Beatles&type=all')
+    })
+
+    it('should encode special characters in query', () => {
+        expect(generateSearchUrl('AC/DC')).toBe('https://www.discogs.com/search/?q=AC%2FDC&type=all')
+    })
+
+    it('should trim whitespace', () => {
+        expect(generateSearchUrl('  Daft Punk  ')).toBe('https://www.discogs.com/search/?q=Daft%20Punk&type=all')
+    })
+})

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,0 +1,9 @@
+/**
+ * Generates a Discogs search URL for the given query.
+ * @param query The text to search for
+ * @returns The formatted Discogs search URL
+ */
+export const generateSearchUrl = (query: string): string => {
+    const encodedQuery = encodeURIComponent(query.trim())
+    return `https://www.discogs.com/search/?q=${encodedQuery}&type=all`
+}


### PR DESCRIPTION
Implements a context menu item to search Discogs for selected text.\n\n- Updates manifest with `contextMenus` permission.\n- Adds background script logic.\n- Includes unit tests for search URL generation.\n\nCloses #19