### PR TITLE
fix: Dark Mode Header Visibility (#20)

### DIFF
--- a/src/content/styles/dark-mode.css
+++ b/src/content/styles/dark-mode.css
@@ -34,6 +34,7 @@ body.discogs-enhancer-dark-mode .statistics {
 }
 
 /* Headers */
+/* Headers */
 body.discogs-enhancer-dark-mode h1,
 body.discogs-enhancer-dark-mode h2,
 body.discogs-enhancer-dark-mode h3,
@@ -42,6 +43,25 @@ body.discogs-enhancer-dark-mode h5,
 body.discogs-enhancer-dark-mode h6,
 body.discogs-enhancer-dark-mode .section_header h3 {
   color: #ffffff !important;
+  background-color: transparent !important;
+}
+
+/* Header Containers & Specific Sections */
+body.discogs-enhancer-dark-mode .section_header,
+body.discogs-enhancer-dark-mode .widget_header,
+body.discogs-enhancer-dark-mode .box_header,
+body.discogs-enhancer-dark-mode .tracklist_header,
+body.discogs-enhancer-dark-mode .profile_header,
+body.discogs-enhancer-dark-mode #release-stats,
+body.discogs-enhancer-dark-mode .head {
+  background-color: #1e1e1e !important;
+  color: #ffffff !important;
+  border-bottom-color: #444 !important;
+}
+
+/* Fix for stats specifically */
+body.discogs-enhancer-dark-mode #release-stats h3 {
+  background-color: transparent !important;
 }
 
 /* Tables */


### PR DESCRIPTION
Fixes visibility issues in dark mode where headers appeared as white text on white background.

- Adds background-color: #1e1e1e to header containers (.section_header, .box_header, #release-stats, etc.)
- Ensures h1-h6 elements have transparent background to inherit the container color.
- Sets specific styles for #release-stats to ensure readability.